### PR TITLE
1. Made JNDI binding optional so that application contexts which do not ...

### DIFF
--- a/interceptors/interceptors-core/src/main/java/org/jboss/spring/factory/Constants.java
+++ b/interceptors/interceptors-core/src/main/java/org/jboss/spring/factory/Constants.java
@@ -25,7 +25,7 @@ package org.jboss.spring.factory;
  * @author Marius Bogoevici
  */
 public class Constants {
-    public static final String BEAN_FACTORY_ELEMENT = "BeanFactory=\\(([^)]+)\\)";
+    public static final String BEAN_FACTORY_ELEMENT = "^BeanFactory=\\(([^)]+)\\)";
     public static final String PARENT_BEAN_FACTORY_ELEMENT = "ParentBeanFactory=\\(([^)]+)\\)";
     public static final String INSTANTIATION_ELEMENT = "Instantiate=\\(([^)]+)\\)";
 }

--- a/interceptors/interceptors-core/src/main/java/org/jboss/spring/factory/NamedXmlApplicationContext.java
+++ b/interceptors/interceptors-core/src/main/java/org/jboss/spring/factory/NamedXmlApplicationContext.java
@@ -82,6 +82,10 @@ public class NamedXmlApplicationContext extends VFSClassPathXmlApplicationContex
         }
         return name;
     }
+    
+    public String getJndiName() {
+      return this.name;
+    }
 
     private void initializeNames(Resource resource) {
         try {
@@ -114,6 +118,9 @@ public class NamedXmlApplicationContext extends VFSClassPathXmlApplicationContex
                 if (pbfm.find()) {
                     String parentName = pbfm.group(1);
                     try {
+                        if (!parentName.startsWith("java:jboss/")) {
+                          parentName = "java:jboss/" + parentName;
+                        }
                         this.getBeanFactory().setParentBeanFactory((BeanFactory) Util.lookup(parentName, BeanFactory.class));
                     } catch (Exception e) {
                         throw new BeanDefinitionStoreException("Failure during parent bean factory JNDI lookup: " + parentName, e);

--- a/subsystem-as7/subsystem-as7/src/main/java/org/jboss/spring/deployers/as7/SpringBootstrapProcessor.java
+++ b/subsystem-as7/subsystem-as7/src/main/java/org/jboss/spring/deployers/as7/SpringBootstrapProcessor.java
@@ -78,21 +78,23 @@ public class SpringBootstrapProcessor implements DeploymentUnitProcessor {
             ServiceName serviceName = phaseContext.getDeploymentUnit().getServiceName().append(applicationContext.getName());
             ServiceBuilder<?> serviceBuilder = serviceTarget.addService(serviceName, service);
             serviceBuilder.install();
-            String jndiName = JndiName.of("java:jboss").append(applicationContext.getName()).getAbsoluteName();
-            int index = jndiName.indexOf("/");
-            String namespace = (index > 5) ? jndiName.substring(5, index) : null;
-            String binding = (index > 5) ? jndiName.substring(index + 1) : jndiName.substring(5);
-            ServiceName naming = (namespace != null) ? ContextNames.JAVA_CONTEXT_SERVICE_NAME.append(namespace) : ContextNames.JAVA_CONTEXT_SERVICE_NAME;
-            ServiceName bindingName = naming.append(binding);
-            BinderService binder = new BinderService(binding);
-            InjectedValue<ApplicationContext> injectedValue = new InjectedValue<ApplicationContext>();
-            final ContextNames.BindInfo bindInfo = ContextNames.bindInfoFor(jndiName);
-            serviceTarget.addService(bindingName, binder)
-                    .addAliases(ContextNames.JAVA_CONTEXT_SERVICE_NAME.append(jndiName))
-                    .addInjection(binder.getManagedObjectInjector(), new ValueManagedReferenceFactory(injectedValue))
-                    .addDependency(serviceName, ApplicationContext.class, injectedValue)
-                    .addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, binder.getNamingStoreInjector())
-                    .install();
+            if (applicationContext.getJndiName() != null) {
+              String jndiName = JndiName.of("java:jboss").append(applicationContext.getName()).getAbsoluteName();
+              int index = jndiName.indexOf("/");
+              String namespace = (index > 5) ? jndiName.substring(5, index) : null;
+              String binding = (index > 5) ? jndiName.substring(index + 1) : jndiName.substring(5);
+              ServiceName naming = (namespace != null) ? ContextNames.JAVA_CONTEXT_SERVICE_NAME.append(namespace) : ContextNames.JAVA_CONTEXT_SERVICE_NAME;
+              ServiceName bindingName = naming.append(binding);
+              BinderService binder = new BinderService(binding);
+              InjectedValue<ApplicationContext> injectedValue = new InjectedValue<ApplicationContext>();
+              final ContextNames.BindInfo bindInfo = ContextNames.bindInfoFor(jndiName);
+              serviceTarget.addService(bindingName, binder)
+                      .addAliases(ContextNames.JAVA_CONTEXT_SERVICE_NAME.append(jndiName))
+                      .addInjection(binder.getManagedObjectInjector(), new ValueManagedReferenceFactory(injectedValue))
+                      .addDependency(serviceName, ApplicationContext.class, injectedValue)
+                      .addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, binder.getNamingStoreInjector())
+                      .install();
+            }
         }
     }
 

--- a/subsystem-as7/subsystem-as7/src/main/java/org/jboss/spring/deployers/as7/SpringResourceDependencyProcessor.java
+++ b/subsystem-as7/subsystem-as7/src/main/java/org/jboss/spring/deployers/as7/SpringResourceDependencyProcessor.java
@@ -1,0 +1,99 @@
+package org.jboss.spring.deployers.as7;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+
+import org.jboss.as.naming.deployment.ContextNames;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.spring.vfs.VFSResource;
+import org.jboss.vfs.VirtualFile;
+import org.springframework.core.io.Resource;
+import org.xml.sax.InputSource;
+
+public class SpringResourceDependencyProcessor
+  implements DeploymentUnitProcessor
+{
+
+  public void deploy(DeploymentPhaseContext phaseContext)
+    throws DeploymentUnitProcessingException
+  {
+    try
+    {
+      SpringDeployment locations = SpringDeployment.retrieveFrom(phaseContext.getDeploymentUnit());
+
+      if (locations == null) {
+        return;
+      }
+
+      for (VirtualFile virtualFile : locations.getContextDefinitionLocations())
+      {
+        Resource resource = new VFSResource(virtualFile);
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        xPath.setNamespaceContext(new NamespaceContext()
+        {
+          public String getNamespaceURI(String prefix) {
+            return "http://www.springframework.org/schema/beans";
+          }
+
+          public String getPrefix(String namespaceURI)
+          {
+            return "beans";
+          }
+
+          public Iterator<String> getPrefixes(String namespaceURI)
+          {
+            return Collections.singleton("beans").iterator();
+          }
+        });
+
+        String expression = "/beans:beans/beans:description";
+        InputSource inputSource = new InputSource(resource.getInputStream());
+
+        String description = xPath.evaluate(expression, inputSource);
+        if (description != null) {
+          Matcher pbfm = Pattern.compile("ParentBeanFactory=\\(([^)]+)\\)").matcher(description);
+
+          if (pbfm.find())
+          {
+
+            ServiceName jndiName = ContextNames.buildServiceName(ContextNames.JBOSS_CONTEXT_SERVICE_NAME, pbfm.group(1));
+
+            phaseContext.getServiceTarget().addDependency(jndiName);
+          }
+
+        }
+
+      }
+
+      SpringResourceDependencyStructure springResourceDependencyStructure = SpringResourceDependencyStructure.retrieveFrom(phaseContext.getDeploymentUnit());
+
+      if (springResourceDependencyStructure != null) {
+        List<String> resourceDependencies = springResourceDependencyStructure.getResources();
+
+        for (String resource : resourceDependencies) {
+          ServiceName resourceJndiName = ContextNames.bindInfoFor(resource).getBinderServiceName();
+          phaseContext.getServiceTarget().addDependency(resourceJndiName);
+        }
+      }
+    }
+    catch (Exception e)
+    {
+      throw new DeploymentUnitProcessingException("Unable to establish Parent Application Context JNDI Dependency Chain", e);
+    }
+  }
+
+  public void undeploy(DeploymentUnit context)
+  {
+  }
+}

--- a/subsystem-as7/subsystem-as7/src/main/java/org/jboss/spring/deployers/as7/SpringResourceDependencyStructure.java
+++ b/subsystem-as7/subsystem-as7/src/main/java/org/jboss/spring/deployers/as7/SpringResourceDependencyStructure.java
@@ -1,0 +1,59 @@
+package org.jboss.spring.deployers.as7;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.spring.vfs.VFSResource;
+import org.jboss.vfs.VirtualFile;
+
+public class SpringResourceDependencyStructure
+{
+  public static final AttachmentKey<SpringResourceDependencyStructure> ATTACHMENT_KEY = AttachmentKey.create(SpringResourceDependencyStructure.class);
+
+  private List<String> resourceDependencies = new ArrayList<String>();
+
+  public SpringResourceDependencyStructure(VirtualFile resourceDependencyLocation) {
+    parseDependencies(resourceDependencyLocation);
+  }
+
+  private void parseDependencies(VirtualFile resourceDependencyLocation) {
+    BufferedReader reader = null;
+    try {
+      reader = new BufferedReader(new InputStreamReader(new VFSResource(resourceDependencyLocation).getInputStream()));
+      String resource;
+      while ((resource = reader.readLine()) != null)
+        this.resourceDependencies.add(resource);
+    }
+    catch (Exception e)
+    {
+      throw new RuntimeException("Unable to parse the resource dependencies for this module");
+    }
+    finally {
+      if (reader != null)
+        try {
+          reader.close();
+        }
+        catch (Exception e2)
+        {
+        }
+    }
+  }
+
+  public List<String> getResources()
+  {
+    return Collections.unmodifiableList(this.resourceDependencies);
+  }
+
+  public void attachTo(DeploymentUnit deploymentUnit) {
+    deploymentUnit.putAttachment(ATTACHMENT_KEY, this);
+  }
+
+  public static SpringResourceDependencyStructure retrieveFrom(DeploymentUnit deploymentUnit)
+  {
+    return (SpringResourceDependencyStructure)deploymentUnit.getAttachment(ATTACHMENT_KEY);
+  }
+}

--- a/subsystem-as7/subsystem-as7/src/main/java/org/jboss/spring/deployers/as7/SpringResourceDependencyStructureProcessor.java
+++ b/subsystem-as7/subsystem-as7/src/main/java/org/jboss/spring/deployers/as7/SpringResourceDependencyStructureProcessor.java
@@ -1,0 +1,36 @@
+package org.jboss.spring.deployers.as7;
+
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.module.ResourceRoot;
+import org.jboss.vfs.VirtualFile;
+
+public class SpringResourceDependencyStructureProcessor
+  implements DeploymentUnitProcessor
+{
+
+  public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException
+  {
+    DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+
+    ResourceRoot deploymentRoot = (ResourceRoot)deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT);
+
+    if (deploymentRoot == null) {
+      return;
+    }
+
+    VirtualFile metaInf = deploymentRoot.getRoot().getChild("META-INF");
+    VirtualFile resourceDependencyLocation = metaInf.getChild("resource-dependencies.properties");
+    if (resourceDependencyLocation.exists()) {
+      SpringResourceDependencyStructure springResourceDependencyStructure = new SpringResourceDependencyStructure(resourceDependencyLocation);
+      springResourceDependencyStructure.attachTo(deploymentUnit);
+    }
+  }
+
+  public void undeploy(DeploymentUnit context)
+  {
+  }
+}

--- a/subsystem-as7/subsystem-as7/src/main/java/org/jboss/spring/deployers/as7/SpringSubsystemAdd.java
+++ b/subsystem-as7/subsystem-as7/src/main/java/org/jboss/spring/deployers/as7/SpringSubsystemAdd.java
@@ -53,7 +53,9 @@ public class SpringSubsystemAdd extends AbstractBoottimeAddStepHandler {
         operationContext.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget bootContext) {
                 bootContext.addDeploymentProcessor(Phase.STRUCTURE, Phase.STRUCTURE_JBOSS_DEPLOYMENT_STRUCTURE_DESCRIPTOR + 1, new SpringStructureProcessor());
+                bootContext.addDeploymentProcessor(Phase.STRUCTURE, Phase.STRUCTURE_JBOSS_DEPLOYMENT_STRUCTURE_DESCRIPTOR + 2, new SpringResourceDependencyStructureProcessor());
                 bootContext.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_DEPENDENCIES_MANIFEST, new SpringDependencyProcessor());
+                bootContext.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_APP_NAMING_CONTEXT, new SpringResourceDependencyProcessor());
                 bootContext.addDeploymentProcessor(Phase.INSTALL, Integer.MAX_VALUE, new SpringBootstrapProcessor());
             }
         }, OperationContext.Stage.RUNTIME);


### PR DESCRIPTION
There are a few things which I wanted to address using Snowdrop

> Ability to refer application contexts from other deployments

With the whole microservices way of doing things, JBoss Modules goes a long way in making sure that applications can be designed in a modular manner specifying dependencies on each other as required. I thought if Snowdrop could be extended to allow beans in one application to refer beans from other applications, it would open up a whole new dimension into designing modular applications. This is a feature which I have tried to introduce in Snowdrop. This has a few challenges in terms of JBoss loading deployments in parallel, so there is no real guarantee that the parent context would be initialized before the child. By introducing proper JBoss service dependencies, I have ensured that the parent application is always loaded before the child

> Ability to refer JNDI resources (Data Sources, JMS Connection Factories, etc.)

Again, due to the problem above, it is not guaranteed that JBoss would have initialized a Data Source before it loads a Spring application which refers to it which results in startup issues. I have introduced the ability to have a property file (resource-dependencies.properties) inside the META-INF of your Spring application and list all JNDI dependencies (one on each line) inside the file. All these dependencies would automatically be honoured before JBoss tries to load the Spring application, hence ensuring proper resource resolution

> Making JNDI binding optional

I think the default Snowdrop behaviour of defaulting JNDI names if it is not explicitly specified in the application context file does not add much value as a feature. Rather, many a time, one would want to not specify any JNDI bindings for cases where this Spring application is not intended to be used as a parent for other contexts or where he does not want to look up this context from a non-Spring environment. Typically lowest level beans do not need to be bound to JNDI. I hence introduced the feature of not binding the context to JNDI if the JNDI name is not provided